### PR TITLE
Use Rust api-server instead of Go one

### DIFF
--- a/initial-data/Makefile
+++ b/initial-data/Makefile
@@ -20,10 +20,10 @@ estate_data: make_estate_data.py
 
 verification_data: ./make_verification_data
 	rm -rf ./result/verification_data
-	docker-compose -f ../webapp/docker-compose/go.yaml down -v
-	docker-compose -f ../webapp/docker-compose/go.yaml up -d mysql api-server
+	docker-compose -f ../webapp/docker-compose/rust.yaml down -v
+	docker-compose -f ../webapp/docker-compose/rust.yaml up -d mysql api-server
 	wayt http -u "http://localhost:1323/api/estate/search/condition"
 	curl -X POST "localhost:1323/initialize"
 	go build -o ./make_verification_data/main ./make_verification_data/*.go
 	./make_verification_data/main -fixture-dir ../webapp/fixture -dest-dir ./result/verification_data -target-url http://localhost:1323
-	docker-compose -f ../webapp/docker-compose/go.yaml down -v
+	docker-compose -f ../webapp/docker-compose/rust.yaml down -v


### PR DESCRIPTION
Goのapi-serverがうまく動作しなかったため、Rustを利用するように修正した。